### PR TITLE
fix: remove orange border on blocks

### DIFF
--- a/styles/_blocks.scss
+++ b/styles/_blocks.scss
@@ -100,7 +100,6 @@
     }
     
     &:focus {
-      @include focus-ring;
       text-decoration: none;
     }
   }


### PR DESCRIPTION
## Description

removes that orange border that is produced when you click on a block on the home page or in a community page