### PR TITLE
Zollinger/add community tag filter

### DIFF
--- a/script.js
+++ b/script.js
@@ -769,31 +769,46 @@
       postsListUl.parentNode.insertBefore(filterContainer, postsListUl);
     }
 
-    // Handle dropdown toggle visibility explicitly
+    let isDropdownOpen = false;
+
+    // Handle dropdown toggle visibility explicitly and locally
     button.addEventListener('click', function(e) {
-      e.stopPropagation();
-      const isExpanded = button.getAttribute('aria-expanded') === 'true';
+      e.preventDefault();
+      e.stopImmediatePropagation(); // Kills any Zendesk native listeners that might interfere
       
-      // close other native dropdowns via Zendesk's global listener by simulating a body click
-      // but we need to stopPropagation right after so we don't close ourselves!
-      // Actually, just explicitly close them:
+      isDropdownOpen = !isDropdownOpen;
+      
+      // close other native dropdowns SAFELY (remove inline styles instead of forcing none)
       document.querySelectorAll('.topic-filters .dropdown-toggle').forEach(btn => {
         if (btn !== button) {
           btn.setAttribute('aria-expanded', 'false');
           const nextMenu = btn.nextElementSibling;
           if (nextMenu && nextMenu.classList.contains('dropdown-menu')) {
-            nextMenu.style.display = 'none';
+            nextMenu.style.display = ''; // Clear inline style so CSS can take over again!
           }
         }
       });
       
-      button.setAttribute('aria-expanded', !isExpanded);
-      dropdownMenu.style.display = isExpanded ? 'none' : 'block';
+      button.setAttribute('aria-expanded', isDropdownOpen ? 'true' : 'false');
+      dropdownMenu.style.display = isDropdownOpen ? 'block' : 'none'; // Explicit override
     });
 
-    document.addEventListener('click', function() {
-      button.setAttribute('aria-expanded', 'false');
-      dropdownMenu.style.display = 'none';
+    function closeTagFilter() {
+      if (isDropdownOpen) {
+        isDropdownOpen = false;
+        button.setAttribute('aria-expanded', 'false');
+        dropdownMenu.style.display = 'none';
+      }
+    }
+
+    // Close when clicking outside
+    document.addEventListener('click', closeTagFilter);
+
+    // Close when clicking other native Zendesk dropdown toggles
+    document.querySelectorAll('.topic-filters .dropdown-toggle').forEach(btn => {
+      if (btn !== button) {
+        btn.addEventListener('click', closeTagFilter);
+      }
     });
 
     // 4. Handle the filtering logic when a selection changes
@@ -812,6 +827,7 @@
       button.innerHTML = `${textToDisplay} <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
 
       // Explicitly close the dropdown menu
+      isDropdownOpen = false;
       button.setAttribute('aria-expanded', 'false');
       dropdownMenu.style.display = 'none';
 

--- a/script.js
+++ b/script.js
@@ -674,21 +674,43 @@
     }
   });
 
-  document.addEventListener("DOMContentLoaded", function () {
+  document.addEventListener("DOMContentLoaded", async function () {
     // Ensure we are on a community topic page
-    const postListings = document.querySelectorAll('.posts-list li');
-    if (postListings.length === 0) return;
+    const postsListUl = document.querySelector('.posts-list > ul');
+    if (!postsListUl) return;
 
-    // 1. Gather all unique tags from the currently loaded posts
-    const uniqueTags = new Set();
-    postListings.forEach(post => {
-      const tags = post.querySelectorAll('.content-tag'); 
-      tags.forEach(tag => {
-        uniqueTags.add(tag.getAttribute('data-tag') || tag.textContent.trim());
+    const allPosts = Array.from(postsListUl.children).filter(el => el.tagName === 'LI');
+    if (allPosts.length === 0) return;
+
+    // 1. Determine if there are multiple pages
+    let totalPages = 1;
+    const pagination = document.querySelector('.pagination');
+    if (pagination) {
+      const pageLinks = pagination.querySelectorAll('a');
+      pageLinks.forEach(link => {
+        const match = link.getAttribute('href')?.match(/[?&]page=(\d+)/);
+        if (match) {
+          const pageNum = parseInt(match[1], 10);
+          if (pageNum > totalPages) totalPages = pageNum;
+        }
       });
-    });
+    }
 
-    if (uniqueTags.size === 0) return; // Exit if no tags exist on the page
+    // Helper to extract tags from a post element
+    function getTagsFromPost(postEl) {
+      const tags = new Set();
+      postEl.querySelectorAll('.content-tag').forEach(tagEl => {
+        tags.add(tagEl.getAttribute('data-tag') || tagEl.textContent.trim());
+      });
+      return Array.from(tags);
+    }
+
+    const uniqueTags = new Set();
+    
+    // Initial populate from page 1
+    allPosts.forEach(post => {
+      getTagsFromPost(post).forEach(tag => uniqueTags.add(tag));
+    });
 
     // 2. Create the custom dropdown menu following Zendesk's native style
     const filterContainer = document.createElement('span');
@@ -703,25 +725,38 @@
     dropdownMenu.className = 'dropdown-menu';
     dropdownMenu.setAttribute('role', 'menu');
 
-    // Add the default 'All' option
-    const defaultOption = document.createElement('a');
-    defaultOption.href = '#';
-    defaultOption.setAttribute('role', 'menuitemradio');
-    defaultOption.setAttribute('aria-checked', 'true');
-    defaultOption.textContent = 'All Tags';
-    defaultOption.setAttribute('data-value', 'all');
-    dropdownMenu.appendChild(defaultOption);
+    // Function to render dropdown options
+    function renderDropdownOptions() {
+      dropdownMenu.innerHTML = ''; // Clear existing
+      
+      // Add the default 'All' option
+      const defaultOption = document.createElement('a');
+      defaultOption.href = '#';
+      defaultOption.setAttribute('role', 'menuitemradio');
+      defaultOption.setAttribute('aria-checked', 'true');
+      defaultOption.textContent = 'All Tags';
+      defaultOption.setAttribute('data-value', 'all');
+      dropdownMenu.appendChild(defaultOption);
 
-    // Add the unique tags to the dropdown
-    uniqueTags.forEach(tag => {
-      const option = document.createElement('a');
-      option.href = '#';
-      option.setAttribute('role', 'menuitemradio');
-      option.setAttribute('aria-checked', 'false');
-      option.textContent = tag;
-      option.setAttribute('data-value', tag.toLowerCase());
-      dropdownMenu.appendChild(option);
-    });
+      // Add the unique tags to the dropdown
+      Array.from(uniqueTags).sort().forEach(tag => {
+        const option = document.createElement('a');
+        option.href = '#';
+        option.setAttribute('role', 'menuitemradio');
+        option.setAttribute('aria-checked', 'false');
+        option.textContent = tag;
+        option.setAttribute('data-value', tag.toLowerCase());
+        dropdownMenu.appendChild(option);
+      });
+
+      // Re-attach event listeners to new options
+      const options = dropdownMenu.querySelectorAll('a');
+      options.forEach(opt => {
+        opt.addEventListener('click', handleOptionClick);
+      });
+    }
+
+    renderDropdownOptions();
 
     filterContainer.appendChild(button);
     filterContainer.appendChild(dropdownMenu);
@@ -730,67 +765,124 @@
     const filterBar = document.querySelector('.topic-filters');
     if (filterBar) {
       filterBar.appendChild(filterContainer);
+    } else {
+      postsListUl.parentNode.insertBefore(filterContainer, postsListUl);
     }
 
-    // Handle dropdown toggle visibility (basic Zendesk theme style)
+    // Handle dropdown toggle visibility explicitly
     button.addEventListener('click', function(e) {
       e.stopPropagation();
       const isExpanded = button.getAttribute('aria-expanded') === 'true';
       
-      // close other native dropdowns
+      // close other native dropdowns via Zendesk's global listener by simulating a body click
+      // but we need to stopPropagation right after so we don't close ourselves!
+      // Actually, just explicitly close them:
       document.querySelectorAll('.topic-filters .dropdown-toggle').forEach(btn => {
-        btn.setAttribute('aria-expanded', 'false');
+        if (btn !== button) {
+          btn.setAttribute('aria-expanded', 'false');
+          const nextMenu = btn.nextElementSibling;
+          if (nextMenu && nextMenu.classList.contains('dropdown-menu')) {
+            nextMenu.style.display = 'none';
+          }
+        }
       });
       
       button.setAttribute('aria-expanded', !isExpanded);
+      dropdownMenu.style.display = isExpanded ? 'none' : 'block';
     });
 
     document.addEventListener('click', function() {
       button.setAttribute('aria-expanded', 'false');
+      dropdownMenu.style.display = 'none';
     });
 
     // 4. Handle the filtering logic when a selection changes
-    const options = dropdownMenu.querySelectorAll('a');
-    options.forEach(opt => {
-      opt.addEventListener('click', function(e) {
-        e.preventDefault();
-        const selectedTagValue = this.getAttribute('data-value');
+    function handleOptionClick(e) {
+      e.preventDefault();
+      const selectedTagValue = this.getAttribute('data-value');
+      
+      // Update checkmarks
+      const options = dropdownMenu.querySelectorAll('a');
+      options.forEach(o => o.setAttribute('aria-checked', 'false'));
+      this.setAttribute('aria-checked', 'true');
+      
+      // Update button text
+      const rawText = this.textContent.trim();
+      const textToDisplay = selectedTagValue === 'all' ? 'Filter by Tag (All)' : rawText;
+      button.innerHTML = `${textToDisplay} <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+
+      // Explicitly close the dropdown menu
+      button.setAttribute('aria-expanded', 'false');
+      dropdownMenu.style.display = 'none';
+
+      // Apply filtering to all dynamically loaded posts
+      allPosts.forEach(post => {
+        if (selectedTagValue === "all") {
+          post.style.display = ""; // Show all
+          return;
+        }
+
+        const postTags = getTagsFromPost(post).map(t => t.toLowerCase());
         
-        // Update checkmarks
-        options.forEach(o => o.setAttribute('aria-checked', 'false'));
-        this.setAttribute('aria-checked', 'true');
-        
-        // Update button text
-        const rawText = this.textContent.trim();
-        const textToDisplay = selectedTagValue === 'all' ? 'Filter by Tag (All)' : rawText;
-        button.innerHTML = `${textToDisplay} <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
-
-        // Apply filtering to posts
-        postListings.forEach(post => {
-          if (selectedTagValue === "all") {
-            post.style.display = ""; // Show all
-            return;
-          }
-
-          // Check if this specific post has the selected tag
-          const tags = post.querySelectorAll('.content-tag');
-          let hasTag = false;
-          tags.forEach(tag => {
-            const tagValue = (tag.getAttribute('data-tag') || tag.textContent.trim()).toLowerCase();
-            if (tagValue === selectedTagValue) {
-              hasTag = true;
-            }
-          });
-
-          // Toggle visibility based on presence of the tag
-          if (hasTag) {
-            post.style.display = "";
-          } else {
-            post.style.display = "none";
-          }
-        });
+        // Toggle visibility based on presence of the tag
+        if (postTags.includes(selectedTagValue)) {
+          post.style.display = "";
+        } else {
+          post.style.display = "none";
+        }
       });
-    });
+    }
+
+    // 5. Fetch remaining pages if they exist
+    if (totalPages > 1) {
+      button.disabled = true;
+      button.style.opacity = '0.7';
+      button.innerHTML = `Loading all posts... <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+
+      try {
+        const baseUrl = new URL(window.location.href);
+        
+        for (let p = 2; p <= totalPages; p++) {
+          baseUrl.searchParams.set('page', p);
+          
+          const response = await fetch(baseUrl.toString());
+          if (!response.ok) continue;
+          
+          const html = await response.text();
+          const parser = new DOMParser();
+          const doc = parser.parseFromString(html, 'text/html');
+          
+          // Find the new posts list ul
+          const newPostsUl = doc.querySelector('.posts-list > ul');
+          if (newPostsUl) {
+            const newPosts = Array.from(newPostsUl.children).filter(el => el.tagName === 'LI');
+            
+            newPosts.forEach(post => {
+              allPosts.push(post);
+              postsListUl.appendChild(post); // Add to DOM, maintaining order
+              getTagsFromPost(post).forEach(tag => uniqueTags.add(tag));
+            });
+          }
+        }
+      } catch (err) {
+        console.error("Failed to load paginated posts", err);
+      } finally {
+        // Re-render dropdown to include tags from other pages
+        renderDropdownOptions();
+        
+        button.disabled = false;
+        button.style.opacity = '1';
+        button.innerHTML = `Filter by Tag (All) <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+        
+        // Hide the native pagination since we loaded everything
+        if (pagination) pagination.style.display = 'none';
+      }
+    } else {
+      // If no unique tags across page 1 and no extra pages
+      if (uniqueTags.size === 0) {
+        filterContainer.style.display = 'none';
+      }
+    }
   });
 
 })();

--- a/script.js
+++ b/script.js
@@ -674,4 +674,123 @@
     }
   });
 
+  document.addEventListener("DOMContentLoaded", function () {
+    // Ensure we are on a community topic page
+    const postListings = document.querySelectorAll('.posts-list li');
+    if (postListings.length === 0) return;
+
+    // 1. Gather all unique tags from the currently loaded posts
+    const uniqueTags = new Set();
+    postListings.forEach(post => {
+      const tags = post.querySelectorAll('.content-tag'); 
+      tags.forEach(tag => {
+        uniqueTags.add(tag.getAttribute('data-tag') || tag.textContent.trim());
+      });
+    });
+
+    if (uniqueTags.size === 0) return; // Exit if no tags exist on the page
+
+    // 2. Create the custom dropdown menu following Zendesk's native style
+    const filterContainer = document.createElement('span');
+    filterContainer.className = 'dropdown post-tag-filter';
+
+    const button = document.createElement('button');
+    button.className = 'dropdown-toggle';
+    button.setAttribute('aria-haspopup', 'true');
+    button.innerHTML = `Filter by Tag (All) <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+
+    const dropdownMenu = document.createElement('span');
+    dropdownMenu.className = 'dropdown-menu';
+    dropdownMenu.setAttribute('role', 'menu');
+
+    // Add the default 'All' option
+    const defaultOption = document.createElement('a');
+    defaultOption.href = '#';
+    defaultOption.setAttribute('role', 'menuitemradio');
+    defaultOption.setAttribute('aria-checked', 'true');
+    defaultOption.textContent = 'All Tags';
+    defaultOption.setAttribute('data-value', 'all');
+    dropdownMenu.appendChild(defaultOption);
+
+    // Add the unique tags to the dropdown
+    uniqueTags.forEach(tag => {
+      const option = document.createElement('a');
+      option.href = '#';
+      option.setAttribute('role', 'menuitemradio');
+      option.setAttribute('aria-checked', 'false');
+      option.textContent = tag;
+      option.setAttribute('data-value', tag.toLowerCase());
+      dropdownMenu.appendChild(option);
+    });
+
+    filterContainer.appendChild(button);
+    filterContainer.appendChild(dropdownMenu);
+
+    // 3. Inject the dropdown next to the existing sorting options
+    const filterBar = document.querySelector('.topic-filters');
+    if (filterBar) {
+      filterBar.appendChild(filterContainer);
+    }
+
+    // Handle dropdown toggle visibility (basic Zendesk theme style)
+    button.addEventListener('click', function(e) {
+      e.stopPropagation();
+      const isExpanded = button.getAttribute('aria-expanded') === 'true';
+      
+      // close other native dropdowns
+      document.querySelectorAll('.topic-filters .dropdown-toggle').forEach(btn => {
+        btn.setAttribute('aria-expanded', 'false');
+      });
+      
+      button.setAttribute('aria-expanded', !isExpanded);
+    });
+
+    document.addEventListener('click', function() {
+      button.setAttribute('aria-expanded', 'false');
+    });
+
+    // 4. Handle the filtering logic when a selection changes
+    const options = dropdownMenu.querySelectorAll('a');
+    options.forEach(opt => {
+      opt.addEventListener('click', function(e) {
+        e.preventDefault();
+        const selectedTagValue = this.getAttribute('data-value');
+        
+        // Update checkmarks
+        options.forEach(o => o.setAttribute('aria-checked', 'false'));
+        this.setAttribute('aria-checked', 'true');
+        
+        // Update button text
+        const rawText = this.textContent.trim();
+        const textToDisplay = selectedTagValue === 'all' ? 'Filter by Tag (All)' : rawText;
+        button.innerHTML = `${textToDisplay} <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+
+        // Apply filtering to posts
+        postListings.forEach(post => {
+          if (selectedTagValue === "all") {
+            post.style.display = ""; // Show all
+            return;
+          }
+
+          // Check if this specific post has the selected tag
+          const tags = post.querySelectorAll('.content-tag');
+          let hasTag = false;
+          tags.forEach(tag => {
+            const tagValue = (tag.getAttribute('data-tag') || tag.textContent.trim()).toLowerCase();
+            if (tagValue === selectedTagValue) {
+              hasTag = true;
+            }
+          });
+
+          // Toggle visibility based on presence of the tag
+          if (hasTag) {
+            post.style.display = "";
+          } else {
+            post.style.display = "none";
+          }
+        });
+      });
+    });
+  });
+
 })();

--- a/script.js
+++ b/script.js
@@ -716,10 +716,34 @@
     const filterContainer = document.createElement('span');
     filterContainer.className = 'dropdown post-tag-filter';
 
+    // Creates a new chevron SVG element (static, no user content)
+    function createChevronSvg() {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('width', '12');
+      svg.setAttribute('height', '12');
+      svg.setAttribute('focusable', 'false');
+      svg.setAttribute('viewBox', '0 0 12 12');
+      svg.classList.add('dropdown-chevron-icon');
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      path.setAttribute('fill', 'none');
+      path.setAttribute('stroke', 'currentColor');
+      path.setAttribute('stroke-linecap', 'round');
+      path.setAttribute('d', 'M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5');
+      svg.appendChild(path);
+      return svg;
+    }
+
+    // Safely sets the button label using textContent to avoid XSS,
+    // then appends the static chevron SVG as a DOM node.
+    function setButtonLabel(text) {
+      button.textContent = text + ' ';
+      button.appendChild(createChevronSvg());
+    }
+
     const button = document.createElement('button');
     button.className = 'dropdown-toggle';
     button.setAttribute('aria-haspopup', 'true');
-    button.innerHTML = `Filter by Tag (All) <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+    setButtonLabel('Filter by Tag (All)');
 
     const dropdownMenu = document.createElement('span');
     dropdownMenu.className = 'dropdown-menu';
@@ -821,10 +845,10 @@
       options.forEach(o => o.setAttribute('aria-checked', 'false'));
       this.setAttribute('aria-checked', 'true');
       
-      // Update button text
+      // Update button text safely (textContent prevents HTML injection)
       const rawText = this.textContent.trim();
       const textToDisplay = selectedTagValue === 'all' ? 'Filter by Tag (All)' : rawText;
-      button.innerHTML = `${textToDisplay} <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+      setButtonLabel(textToDisplay);
 
       // Explicitly close the dropdown menu
       isDropdownOpen = false;
@@ -853,7 +877,7 @@
     if (totalPages > 1) {
       button.disabled = true;
       button.style.opacity = '0.7';
-      button.innerHTML = `Loading all posts... <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+      setButtonLabel('Loading all posts...');
 
       try {
         const baseUrl = new URL(window.location.href);
@@ -888,7 +912,7 @@
         
         button.disabled = false;
         button.style.opacity = '1';
-        button.innerHTML = `Filter by Tag (All) <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+        setButtonLabel('Filter by Tag (All)');
         
         // Hide the native pagination since we loaded everything
         if (pagination) pagination.style.display = 'none';

--- a/src/community-tags.js
+++ b/src/community-tags.js
@@ -93,21 +93,31 @@ document.addEventListener("DOMContentLoaded", async function () {
     postsListUl.parentNode.insertBefore(filterContainer, postsListUl);
   }
 
-  // Handle dropdown toggle visibility (basic Zendesk theme style)
+  // Handle dropdown toggle visibility explicitly
   button.addEventListener('click', function(e) {
     e.stopPropagation();
     const isExpanded = button.getAttribute('aria-expanded') === 'true';
     
-    // close other native dropdowns
+    // close other native dropdowns via Zendesk's global listener by simulating a body click
+    // but we need to stopPropagation right after so we don't close ourselves!
+    // Actually, just explicitly close them:
     document.querySelectorAll('.topic-filters .dropdown-toggle').forEach(btn => {
-      btn.setAttribute('aria-expanded', 'false');
+      if (btn !== button) {
+        btn.setAttribute('aria-expanded', 'false');
+        const nextMenu = btn.nextElementSibling;
+        if (nextMenu && nextMenu.classList.contains('dropdown-menu')) {
+          nextMenu.style.display = 'none';
+        }
+      }
     });
     
     button.setAttribute('aria-expanded', !isExpanded);
+    dropdownMenu.style.display = isExpanded ? 'none' : 'block';
   });
 
   document.addEventListener('click', function() {
     button.setAttribute('aria-expanded', 'false');
+    dropdownMenu.style.display = 'none';
   });
 
   // 4. Handle the filtering logic when a selection changes
@@ -124,6 +134,10 @@ document.addEventListener("DOMContentLoaded", async function () {
     const rawText = this.textContent.trim();
     const textToDisplay = selectedTagValue === 'all' ? 'Filter by Tag (All)' : rawText;
     button.innerHTML = `${textToDisplay} <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+
+    // Explicitly close the dropdown menu
+    button.setAttribute('aria-expanded', 'false');
+    dropdownMenu.style.display = 'none';
 
     // Apply filtering to all dynamically loaded posts
     allPosts.forEach(post => {

--- a/src/community-tags.js
+++ b/src/community-tags.js
@@ -40,10 +40,34 @@ document.addEventListener("DOMContentLoaded", async function () {
   const filterContainer = document.createElement('span');
   filterContainer.className = 'dropdown post-tag-filter';
 
+  // Creates a new chevron SVG element (static, no user content)
+  function createChevronSvg() {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('width', '12');
+    svg.setAttribute('height', '12');
+    svg.setAttribute('focusable', 'false');
+    svg.setAttribute('viewBox', '0 0 12 12');
+    svg.classList.add('dropdown-chevron-icon');
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('fill', 'none');
+    path.setAttribute('stroke', 'currentColor');
+    path.setAttribute('stroke-linecap', 'round');
+    path.setAttribute('d', 'M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5');
+    svg.appendChild(path);
+    return svg;
+  }
+
+  // Safely sets the button label using textContent to avoid XSS,
+  // then appends the static chevron SVG as a DOM node.
+  function setButtonLabel(text) {
+    button.textContent = text + ' ';
+    button.appendChild(createChevronSvg());
+  }
+
   const button = document.createElement('button');
   button.className = 'dropdown-toggle';
   button.setAttribute('aria-haspopup', 'true');
-  button.innerHTML = `Filter by Tag (All) <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+  setButtonLabel('Filter by Tag (All)');
 
   const dropdownMenu = document.createElement('span');
   dropdownMenu.className = 'dropdown-menu';
@@ -145,10 +169,10 @@ document.addEventListener("DOMContentLoaded", async function () {
     options.forEach(o => o.setAttribute('aria-checked', 'false'));
     this.setAttribute('aria-checked', 'true');
     
-    // Update button text
+    // Update button text safely (textContent prevents HTML injection)
     const rawText = this.textContent.trim();
     const textToDisplay = selectedTagValue === 'all' ? 'Filter by Tag (All)' : rawText;
-    button.innerHTML = `${textToDisplay} <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+    setButtonLabel(textToDisplay);
 
     // Explicitly close the dropdown menu
     isDropdownOpen = false;
@@ -177,7 +201,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   if (totalPages > 1) {
     button.disabled = true;
     button.style.opacity = '0.7';
-    button.innerHTML = `Loading all posts... <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+    setButtonLabel('Loading all posts...');
 
     try {
       const baseUrl = new URL(window.location.href);
@@ -212,7 +236,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       
       button.disabled = false;
       button.style.opacity = '1';
-      button.innerHTML = `Filter by Tag (All) <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+      setButtonLabel('Filter by Tag (All)');
       
       // Hide the native pagination since we loaded everything
       if (pagination) pagination.style.display = 'none';

--- a/src/community-tags.js
+++ b/src/community-tags.js
@@ -93,31 +93,46 @@ document.addEventListener("DOMContentLoaded", async function () {
     postsListUl.parentNode.insertBefore(filterContainer, postsListUl);
   }
 
-  // Handle dropdown toggle visibility explicitly
+  let isDropdownOpen = false;
+
+  // Handle dropdown toggle visibility explicitly and locally
   button.addEventListener('click', function(e) {
-    e.stopPropagation();
-    const isExpanded = button.getAttribute('aria-expanded') === 'true';
+    e.preventDefault();
+    e.stopImmediatePropagation(); // Kills any Zendesk native listeners that might interfere
     
-    // close other native dropdowns via Zendesk's global listener by simulating a body click
-    // but we need to stopPropagation right after so we don't close ourselves!
-    // Actually, just explicitly close them:
+    isDropdownOpen = !isDropdownOpen;
+    
+    // close other native dropdowns SAFELY (remove inline styles instead of forcing none)
     document.querySelectorAll('.topic-filters .dropdown-toggle').forEach(btn => {
       if (btn !== button) {
         btn.setAttribute('aria-expanded', 'false');
         const nextMenu = btn.nextElementSibling;
         if (nextMenu && nextMenu.classList.contains('dropdown-menu')) {
-          nextMenu.style.display = 'none';
+          nextMenu.style.display = ''; // Clear inline style so CSS can take over again!
         }
       }
     });
     
-    button.setAttribute('aria-expanded', !isExpanded);
-    dropdownMenu.style.display = isExpanded ? 'none' : 'block';
+    button.setAttribute('aria-expanded', isDropdownOpen ? 'true' : 'false');
+    dropdownMenu.style.display = isDropdownOpen ? 'block' : 'none'; // Explicit override
   });
 
-  document.addEventListener('click', function() {
-    button.setAttribute('aria-expanded', 'false');
-    dropdownMenu.style.display = 'none';
+  function closeTagFilter() {
+    if (isDropdownOpen) {
+      isDropdownOpen = false;
+      button.setAttribute('aria-expanded', 'false');
+      dropdownMenu.style.display = 'none';
+    }
+  }
+
+  // Close when clicking outside
+  document.addEventListener('click', closeTagFilter);
+
+  // Close when clicking other native Zendesk dropdown toggles
+  document.querySelectorAll('.topic-filters .dropdown-toggle').forEach(btn => {
+    if (btn !== button) {
+      btn.addEventListener('click', closeTagFilter);
+    }
   });
 
   // 4. Handle the filtering logic when a selection changes
@@ -136,6 +151,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     button.innerHTML = `${textToDisplay} <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
 
     // Explicitly close the dropdown menu
+    isDropdownOpen = false;
     button.setAttribute('aria-expanded', 'false');
     dropdownMenu.style.display = 'none';
 

--- a/src/community-tags.js
+++ b/src/community-tags.js
@@ -1,0 +1,196 @@
+document.addEventListener("DOMContentLoaded", async function () {
+  // Ensure we are on a community topic page
+  const postsListUl = document.querySelector('.posts-list > ul');
+  if (!postsListUl) return;
+
+  const allPosts = Array.from(postsListUl.children).filter(el => el.tagName === 'LI');
+  if (allPosts.length === 0) return;
+
+  // 1. Determine if there are multiple pages
+  let totalPages = 1;
+  const pagination = document.querySelector('.pagination');
+  if (pagination) {
+    const pageLinks = pagination.querySelectorAll('a');
+    pageLinks.forEach(link => {
+      const match = link.getAttribute('href')?.match(/[?&]page=(\d+)/);
+      if (match) {
+        const pageNum = parseInt(match[1], 10);
+        if (pageNum > totalPages) totalPages = pageNum;
+      }
+    });
+  }
+
+  // Helper to extract tags from a post element
+  function getTagsFromPost(postEl) {
+    const tags = new Set();
+    postEl.querySelectorAll('.content-tag').forEach(tagEl => {
+      tags.add(tagEl.getAttribute('data-tag') || tagEl.textContent.trim());
+    });
+    return Array.from(tags);
+  }
+
+  const uniqueTags = new Set();
+  
+  // Initial populate from page 1
+  allPosts.forEach(post => {
+    getTagsFromPost(post).forEach(tag => uniqueTags.add(tag));
+  });
+
+  // 2. Create the custom dropdown menu following Zendesk's native style
+  const filterContainer = document.createElement('span');
+  filterContainer.className = 'dropdown post-tag-filter';
+
+  const button = document.createElement('button');
+  button.className = 'dropdown-toggle';
+  button.setAttribute('aria-haspopup', 'true');
+  button.innerHTML = `Filter by Tag (All) <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+
+  const dropdownMenu = document.createElement('span');
+  dropdownMenu.className = 'dropdown-menu';
+  dropdownMenu.setAttribute('role', 'menu');
+
+  // Function to render dropdown options
+  function renderDropdownOptions() {
+    dropdownMenu.innerHTML = ''; // Clear existing
+    
+    // Add the default 'All' option
+    const defaultOption = document.createElement('a');
+    defaultOption.href = '#';
+    defaultOption.setAttribute('role', 'menuitemradio');
+    defaultOption.setAttribute('aria-checked', 'true');
+    defaultOption.textContent = 'All Tags';
+    defaultOption.setAttribute('data-value', 'all');
+    dropdownMenu.appendChild(defaultOption);
+
+    // Add the unique tags to the dropdown
+    Array.from(uniqueTags).sort().forEach(tag => {
+      const option = document.createElement('a');
+      option.href = '#';
+      option.setAttribute('role', 'menuitemradio');
+      option.setAttribute('aria-checked', 'false');
+      option.textContent = tag;
+      option.setAttribute('data-value', tag.toLowerCase());
+      dropdownMenu.appendChild(option);
+    });
+
+    // Re-attach event listeners to new options
+    const options = dropdownMenu.querySelectorAll('a');
+    options.forEach(opt => {
+      opt.addEventListener('click', handleOptionClick);
+    });
+  }
+
+  renderDropdownOptions();
+
+  filterContainer.appendChild(button);
+  filterContainer.appendChild(dropdownMenu);
+
+  // 3. Inject the dropdown next to the existing sorting options
+  const filterBar = document.querySelector('.topic-filters');
+  if (filterBar) {
+    filterBar.appendChild(filterContainer);
+  } else {
+    postsListUl.parentNode.insertBefore(filterContainer, postsListUl);
+  }
+
+  // Handle dropdown toggle visibility (basic Zendesk theme style)
+  button.addEventListener('click', function(e) {
+    e.stopPropagation();
+    const isExpanded = button.getAttribute('aria-expanded') === 'true';
+    
+    // close other native dropdowns
+    document.querySelectorAll('.topic-filters .dropdown-toggle').forEach(btn => {
+      btn.setAttribute('aria-expanded', 'false');
+    });
+    
+    button.setAttribute('aria-expanded', !isExpanded);
+  });
+
+  document.addEventListener('click', function() {
+    button.setAttribute('aria-expanded', 'false');
+  });
+
+  // 4. Handle the filtering logic when a selection changes
+  function handleOptionClick(e) {
+    e.preventDefault();
+    const selectedTagValue = this.getAttribute('data-value');
+    
+    // Update checkmarks
+    const options = dropdownMenu.querySelectorAll('a');
+    options.forEach(o => o.setAttribute('aria-checked', 'false'));
+    this.setAttribute('aria-checked', 'true');
+    
+    // Update button text
+    const rawText = this.textContent.trim();
+    const textToDisplay = selectedTagValue === 'all' ? 'Filter by Tag (All)' : rawText;
+    button.innerHTML = `${textToDisplay} <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+
+    // Apply filtering to all dynamically loaded posts
+    allPosts.forEach(post => {
+      if (selectedTagValue === "all") {
+        post.style.display = ""; // Show all
+        return;
+      }
+
+      const postTags = getTagsFromPost(post).map(t => t.toLowerCase());
+      
+      // Toggle visibility based on presence of the tag
+      if (postTags.includes(selectedTagValue)) {
+        post.style.display = "";
+      } else {
+        post.style.display = "none";
+      }
+    });
+  }
+
+  // 5. Fetch remaining pages if they exist
+  if (totalPages > 1) {
+    button.disabled = true;
+    button.style.opacity = '0.7';
+    button.innerHTML = `Loading all posts... <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+
+    try {
+      const baseUrl = new URL(window.location.href);
+      
+      for (let p = 2; p <= totalPages; p++) {
+        baseUrl.searchParams.set('page', p);
+        
+        const response = await fetch(baseUrl.toString());
+        if (!response.ok) continue;
+        
+        const html = await response.text();
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        
+        // Find the new posts list ul
+        const newPostsUl = doc.querySelector('.posts-list > ul');
+        if (newPostsUl) {
+          const newPosts = Array.from(newPostsUl.children).filter(el => el.tagName === 'LI');
+          
+          newPosts.forEach(post => {
+            allPosts.push(post);
+            postsListUl.appendChild(post); // Add to DOM, maintaining order
+            getTagsFromPost(post).forEach(tag => uniqueTags.add(tag));
+          });
+        }
+      }
+    } catch (err) {
+      console.error("Failed to load paginated posts", err);
+    } finally {
+      // Re-render dropdown to include tags from other pages
+      renderDropdownOptions();
+      
+      button.disabled = false;
+      button.style.opacity = '1';
+      button.innerHTML = `Filter by Tag (All) <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/></svg>`;
+      
+      // Hide the native pagination since we loaded everything
+      if (pagination) pagination.style.display = 'none';
+    }
+  } else {
+    // If no unique tags across page 1 and no extra pages
+    if (uniqueTags.size === 0) {
+      filterContainer.style.display = 'none';
+    }
+  }
+});

--- a/src/index.js
+++ b/src/index.js
@@ -5,3 +5,4 @@ import "./dropdowns";
 import "./share";
 import "./search";
 import "./forms";
+import "./community-tags";

--- a/style.css
+++ b/style.css
@@ -1238,11 +1238,14 @@ footer #legal .ml:before {
   }
 }
 .breadcrumbs li {
-  color: lighten($text_color, 20%);
+  color: #87929D;
   font-size: 13px;
   max-width: 450px;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.breadcrumbs li a {
+  color: #87929D;
 }
 .breadcrumbs li + li::before {
   content: ">";
@@ -2919,7 +2922,7 @@ footer #legal .ml:before {
   }
 }
 .topic-header .topic-filters .dropdown-toggle {
-  color: #87929d;
+  color: #87929D;
 }
 
 .no-posts-with-filter {
@@ -3129,6 +3132,13 @@ footer #legal .ml:before {
   }
 }
 .striped-list-count-item:last-child::after {
+  display: none;
+}
+.striped-list-count-item.is-empty {
+  visibility: hidden;
+  pointer-events: none;
+}
+.striped-list-count-item.is-empty .striped-list-number {
   display: none;
 }
 .striped-list-number {

--- a/style.css
+++ b/style.css
@@ -2918,6 +2918,9 @@ footer #legal .ml:before {
     padding: 0;
   }
 }
+.topic-header .topic-filters .dropdown-toggle {
+  color: #87929d;
+}
 
 .no-posts-with-filter {
   margin-top: 20px;
@@ -2985,7 +2988,7 @@ footer #legal .ml:before {
   align-items: flex-start;
   border-bottom: 1px solid rgb(216, 220, 222);
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   justify-content: flex-end;
   padding: 20px 0;
 }
@@ -2995,24 +2998,86 @@ footer #legal .ml:before {
     flex-direction: row;
   }
 }
+.striped-list .post-status-icon {
+  flex-shrink: 0;
+}
+.striped-list .post-status-icon svg {
+  display: block;
+}
+.striped-list .post-status-icon.status-none {
+  color: #c72a1c;
+}
+.striped-list .post-status-icon.status-new {
+  color: #ffb648;
+}
+.striped-list .post-status-icon.status-planned {
+  color: #1f73b7;
+}
+.striped-list .post-status-icon.status-not_planned {
+  color: lighten($text_color, 20%);
+}
+.striped-list .post-status-icon.status-answered, .striped-list .post-status-icon.status-completed {
+  color: #8250df;
+}
 .striped-list-info {
   flex: 2;
+  display: flex;
+  flex-direction: column;
 }
 .striped-list-title {
-  color: $link_color;
-  margin-bottom: 10px;
+  color: #000;
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 4px;
   margin-right: 5px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
 }
 .striped-list-title:hover, .striped-list-title:focus, .striped-list-title:active {
   text-decoration: underline;
 }
 .striped-list-title:visited {
-  color: $visited_link_color;
+  color: #000;
 }
 .striped-list .meta-group {
-  margin: 5px 0;
+  margin: 0;
+  margin-left: 26px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: #87929d;
+  font-size: 13px;
+}
+.striped-list .meta-group .meta-data {
+  color: inherit;
+}
+.striped-list .meta-group .tags-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.striped-list .meta-group .tags-list .content-tag {
+  background-color: transparent;
+  border: 1px solid #d8dcde;
+  border-radius: 2em;
+  padding: 0 8px;
+  font-size: 12px;
+  line-height: 18px;
+  color: lighten($text_color, 20%);
+}
+.striped-list .meta-group .tags-list .content-tag .tags-list-item {
+  color: inherit;
 }
 .striped-list-count {
+  display: flex;
+  flex-direction: column;
+  margin-top: 10px;
   color: lighten($text_color, 20%);
   font-size: 13px;
   justify-content: flex-start;
@@ -3023,7 +3088,13 @@ footer #legal .ml:before {
     display: flex;
     flex: 1;
     justify-content: space-around;
+    margin-top: 0;
+    flex-direction: row;
   }
+}
+.striped-list-count-item {
+  display: flex;
+  align-items: center;
 }
 .striped-list-count-item::after {
   content: "·";

--- a/style.css
+++ b/style.css
@@ -2927,17 +2927,38 @@ footer #legal .ml:before {
   margin-bottom: 20px;
 }
 
-/* Topic, post and user follow button */
-.community-follow {
-  margin-bottom: 10px;
+/* Header Actions Container */
+.header-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
   width: 100%;
+  margin-top: 15px;
 }
 @media (min-width: 768px) {
-  .community-follow {
-    margin-bottom: 0;
+  .header-actions {
+    flex-direction: row;
     width: auto;
   }
 }
+@media (min-width: 1024px) {
+  .header-actions {
+    margin-top: 0;
+  }
+}
+.header-actions .community-follow,
+.header-actions .post-to-community {
+  margin: 0;
+  width: 100%;
+}
+@media (min-width: 768px) {
+  .header-actions .community-follow,
+  .header-actions .post-to-community {
+    width: auto;
+  }
+}
+
+/* Topic, post and user follow button */
 .community-follow button {
   line-height: 30px;
   padding: 0 10px 0 15px;
@@ -2957,10 +2978,10 @@ footer #legal .ml:before {
   border-color: darken($brand_color, 20%);
 }
 .community-follow button::after {
+  display: none;
   border-left: 1px solid white;
   content: attr(data-follower-count);
   color: white;
-  display: inline-block;
   font-family: $heading_font;
   margin-left: 15px;
   padding-left: 10px;
@@ -2970,6 +2991,7 @@ footer #legal .ml:before {
 @media (min-width: 768px) {
   .community-follow button::after {
     position: static;
+    display: inline-block;
   }
 }
 [dir=rtl] .community-follow button::after {

--- a/style.css
+++ b/style.css
@@ -3030,19 +3030,19 @@ footer #legal .ml:before {
   display: block;
 }
 .striped-list .post-status-icon.status-none {
-  color: #c72a1c;
+  color: #71AA32;
 }
 .striped-list .post-status-icon.status-new {
-  color: #ffb648;
+  color: #E1BC21;
 }
 .striped-list .post-status-icon.status-planned {
-  color: #1f73b7;
+  color: #009EB9;
 }
 .striped-list .post-status-icon.status-not_planned {
-  color: lighten($text_color, 20%);
+  color: #989B9F;
 }
 .striped-list .post-status-icon.status-answered, .striped-list .post-status-icon.status-completed {
-  color: #8250df;
+  color: #71AA32;
 }
 .striped-list-info {
   flex: 2;

--- a/style.css
+++ b/style.css
@@ -1080,7 +1080,7 @@ a.header-link {
   color: $brand_color;
   border: 2px solid #fff;
   border-radius: 50%;
-  background-color: transparent; /* Removed teal background per user request */
+  background-color: $background_color; /* Removed teal background per user request */
   bottom: -4px;
   font-size: 17px;
   height: 17px;

--- a/styles/_breadcrumbs.scss
+++ b/styles/_breadcrumbs.scss
@@ -7,16 +7,20 @@
   margin: 0 0 15px 0;
   padding: 0;
   display: flex;
-  
+
 
   li {
-    color: $secondary-text-color;
+    color: $high-contrast-border-color;
     font-size: $font-size-small;
     max-width: 450px;
     overflow: hidden;
     text-overflow: ellipsis;
 
-    + li::before {
+    a {
+      color: $high-contrast-border-color;
+    }
+
+    +li::before {
       content: ">";
       margin: 0 4px;
     }

--- a/styles/_community.scss
+++ b/styles/_community.scss
@@ -103,7 +103,7 @@
 
   .topic-filters {
     .dropdown-toggle {
-      color: #87929d;
+      color: $high-contrast-border-color;
     }
   }
 }

--- a/styles/_community.scss
+++ b/styles/_community.scss
@@ -1,9 +1,9 @@
 /***** Community *****/
 .community {
-//   &-hero {
-//     background-image: url($community_background_image);
-//     margin-bottom: 10px;
-//   }
+  //   &-hero {
+  //     background-image: url($community_background_image);
+  //     margin-bottom: 10px;
+  //   }
 
   &-footer {
     padding-top: 50px;
@@ -14,33 +14,33 @@
       margin-bottom: 20px;
     }
 
-    .button 
-    {
+    .button {
       font-size: 16px;
       padding: 0 16px;
       background-color: transparent;
       border: 2px solid $low-contrast-border-color;
       color: $high-contrast-border-color !important;
-      &:hover 
-      {
+
+      &:hover {
         background-color: white !important;
         border: 2px solid $high-contrast-border-color;
         color: $text_color !important;
       }
+
       margin-bottom: 32px;
     }
   }
 
-//   &-featured-posts .title {
-//     font-size: 18px;
-//     font-weight: 600;
-//   }
+  //   &-featured-posts .title {
+  //     font-size: 18px;
+  //     font-weight: 600;
+  //   }
 
-//   &-featured-posts,
-//   &-activity {
-//     padding-top: 40px;
-//     width: 100%;
-//   }
+  //   &-featured-posts,
+  //   &-activity {
+  //     padding-top: 40px;
+  //     width: 100%;
+  //   }
 
   &-header {
     margin-bottom: 30px;
@@ -53,10 +53,13 @@
 }
 
 .post-to-community {
-  @include tablet { margin: 0; }
+  @include tablet {
+    margin: 0;
+  }
+
   margin-top: 10px;
-  .button 
-  {
+
+  .button {
     padding: 0 16px;
   }
 }
@@ -78,7 +81,10 @@
 /* Community topic page */
 
 .topic-header {
-  @include tablet { padding-bottom: 10px; }
+  @include tablet {
+    padding-bottom: 10px;
+  }
+
   border-bottom: 1px solid $low-contrast-border-color;
   font-size: $font-size-small;
 
@@ -107,34 +113,53 @@
   margin-bottom: 20px;
 }
 
-/* Topic, post and user follow button */
-.community-follow {
+/* Header Actions Container */
+.header-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  width: 100%;
+  margin-top: 15px;
+
   @include tablet {
-    margin-bottom: 0;
+    flex-direction: row;
     width: auto;
   }
 
-  margin-bottom: 10px;
-  width: 100%;
+  @include desktop {
+    margin-top: 0;
+  }
 
+  .community-follow,
+  .post-to-community {
+    margin: 0; // Strip old margins so flex gap can handle spacing cleanly
+    width: 100%;
+
+    @include tablet {
+      width: auto;
+    }
+  }
+}
+
+/* Topic, post and user follow button */
+.community-follow {
   button {
     @extend .button;
-    @include tablet { width: auto;}
+
+    @include tablet {
+      width: auto;
+    }
 
     line-height: 30px;
     padding: 0 10px 0 15px;
     position: relative;
     width: 100%;
 
-    &:hover { background-color: $brand_color; }
-
-    // &:hover::after, &:focus::after {
-    //   border-color: $brand_text_color;
-    //   color: $brand_text_color;
-    // }
+    &:hover {
+      background-color: $brand_color;
+    }
 
     &[data-selected="true"] {
-
       &:hover {
         background-color: $hover-button-color;
         border-color: $hover-button-color;
@@ -144,12 +169,13 @@
     &::after {
       @include tablet {
         position: static;
+        display: inline-block;
       }
 
+      display: none; // Omit follower count on mobile
       border-left: 1px solid white;
       content: attr(data-follower-count);
       color: white;
-      display: inline-block;
       font-family: $heading_font;
       margin-left: 15px;
       padding-left: 10px;
@@ -165,5 +191,3 @@
     }
   }
 }
-
-

--- a/styles/_community.scss
+++ b/styles/_community.scss
@@ -94,6 +94,12 @@
     border-top: 1px solid $low-contrast-border-color;
     padding: 10px 0;
   }
+
+  .topic-filters {
+    .dropdown-toggle {
+      color: #87929d;
+    }
+  }
 }
 
 .no-posts-with-filter {

--- a/styles/_striped_list.scss
+++ b/styles/_striped_list.scss
@@ -24,11 +24,11 @@
       display: block;
     }
 
-    &.status-none { color: #c72a1c; }
-    &.status-new { color: #ffb648; }
-    &.status-planned { color: #1f73b7; }
-    &.status-not_planned { color: $secondary-text-color; }
-    &.status-answered, &.status-completed { color: #8250df; }
+    &.status-none { color: $palette-green; }                          // open — active/live
+    &.status-new { color: $palette-gold; }                            // new — attention/featured
+    &.status-planned { color: $palette-teal; }                        // planned — in motion
+    &.status-not_planned { color: $palette-grey-mid; }                // not planned — de-emphasized
+    &.status-answered, &.status-completed { color: $palette-green; }  // resolved — success
   }
 
   &-info {

--- a/styles/_striped_list.scss
+++ b/styles/_striped_list.scss
@@ -12,19 +12,40 @@
     align-items: flex-start;
     border-bottom: 1px solid $low-contrast-border-color;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     justify-content: flex-end;
     padding: 20px 0;
   }
 
+  .post-status-icon {
+    flex-shrink: 0;
+    
+    svg {
+      display: block;
+    }
+
+    &.status-none { color: #c72a1c; }
+    &.status-new { color: #ffb648; }
+    &.status-planned { color: #1f73b7; }
+    &.status-not_planned { color: $secondary-text-color; }
+    &.status-answered, &.status-completed { color: #8250df; }
+  }
+
   &-info {
     flex: 2;
+    display: flex;
+    flex-direction: column;
   }
 
   &-title {
-    color: $link_color;
-    margin-bottom: 10px;
+    color: #000;
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 4px;
     margin-right: 5px;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
 
     &:hover,
     &:focus,
@@ -32,11 +53,46 @@
       text-decoration: underline;
     }
 
-    &:visited { color: $visited_link_color; }
+    &:visited { color: #000; }
   }
 
   .meta-group {
-    margin: 5px 0;
+    margin: 0;
+    margin-left: 26px;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    color: #87929d;
+    font-size: 13px;
+    
+    .meta-data {
+      color: inherit;
+    }
+
+    .tags-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      gap: 6px;
+      align-items: center;
+      flex-wrap: wrap;
+
+      .content-tag {
+        background-color: transparent;
+        border: 1px solid $menu-border-color;
+        border-radius: 2em;
+        padding: 0 8px;
+        font-size: 12px;
+        line-height: 18px;
+        color: $secondary-text-color;
+        
+        .tags-list-item {
+          color: inherit;
+        }
+      }
+    }
   }
 
   &-count {
@@ -44,14 +100,23 @@
       display: flex;
       flex: 1;
       justify-content: space-around;
+      margin-top: 0;
+      flex-direction: row;
     }
 
+    display: flex;
+    flex-direction: column;
+    margin-top: 10px;
     color: $secondary-text-color;
     font-size: $font-size-small;
     justify-content: flex-start;
     text-transform: capitalize;
   }
+  
   &-count-item {
+    display: flex;
+    align-items: center;
+    
     &::after {
       @include tablet { display: none; }
 

--- a/styles/_striped_list.scss
+++ b/styles/_striped_list.scss
@@ -126,6 +126,15 @@
     }
 
     &:last-child::after { display: none; }
+
+    &.is-empty {
+      visibility: hidden;
+      pointer-events: none;
+
+      .striped-list-number {
+        display: none;
+      }
+    }
   }
 
   &-number {

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -4,6 +4,16 @@
 $hover-button-color: zass-darken($brand_color, 20%);
 $secondary-text-color: zass-lighten($text_color, 20%);
 
+// Brand palette
+$palette-green:       #71AA32; // PMS 368 C — active, success, open
+$palette-teal:        #009EB9; // PMS 7703 C — in-progress, links
+$palette-orange:      #EF5E39; // PMS 151 C — brand primary accent
+$palette-gold:        #E1BC21; // PMS 116 C — new, attention
+$palette-brown:       #674B3E; // PMS 7603 — closed, inactive
+$palette-grey-mid:    #989B9F; // mid grey — muted/secondary
+$palette-grey-light:  #BBBDC0; // light grey — borders, subtle
+$palette-grey-subtle: #E5E3E3; // very light grey — backgrounds
+
 $primary-shade: zass-darken($background_color, 3%); //#f8f8f8 for the default background_color
 $secondary-shade: zass-darken($background_color, 5%); //#f2f2f2 for the default background_color
 

--- a/templates/community_topic_page.hbs
+++ b/templates/community_topic_page.hbs
@@ -113,7 +113,7 @@
                     <ul class="tags-list" style="list-style: none; padding: 0; margin: 0; display: flex; gap: 8px; flex-wrap: wrap;">
                       {{#each content_tags}}
                         <li class="content-tag" data-tag="{{name}}" style="background-color: #eee; border-radius: 4px; padding: 2px 8px; font-size: 12px;">
-                          <a href="{{url}}" class="tags-list-item" style="color: #333; text-decoration: none;">{{name}}</a>
+                          <span class="tags-list-item" style="color: #333; text-decoration: none;">{{name}}</span>
                         </li>
                       {{/each}}
                     </ul>

--- a/templates/community_topic_page.hbs
+++ b/templates/community_topic_page.hbs
@@ -82,54 +82,66 @@
           <li>
             <section role="region" aria-labelledby="title-{{id}}" class="striped-list-item {{#if featured}}post-featured{{/if}}">
               <span class="striped-list-info">
-                <a href="{{url}}" id="title-{{id}}" class="striped-list-title">{{title}}</a>
-                <span class="post-overview-item">
-                  {{#if pinned}}
-                    <span class="status-label status-label-pinned">{{t 'pinned'}}</span>
-                  {{/if}}
-
-                  {{#if featured}}
-                    <span class="status-label status-label-featured">{{t 'featured'}}</span>
-                  {{/if}}
-
-                  {{#is status 'none'}}
-                  {{else}}
-                    <span class="status-label-{{status_dasherized}} status-label striped-list-status">{{status_name}}</span>
-                  {{/is}}
-                </span>
+                <a href="{{url}}" id="title-{{id}}" class="striped-list-title">
+                  <span class="post-status-icon status-{{status_dasherized}}" title="{{#is status 'none'}}Open{{else}}{{status_name}}{{/is}}">
+                    {{#is status 'none'}}
+                      <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"></path></svg>
+                    {{else}}
+                      {{#is status 'planned'}}
+                        <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm7-3.25v2.992l2.028 1.122a.75.75 0 0 1-.724 1.308l-2.433-1.346A.75.75 0 0 1 7 8.16V4.75a.75.75 0 0 1 1.5 0Z"></path></svg>
+                      {{/is}}
+                      {{#is status 'not_planned'}}
+                        <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0Zm0 1.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13Zm0 2a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9Z"></path></svg>
+                      {{/is}}
+                      {{#is status 'answered'}}
+                        <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"></path><path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"></path></svg>
+                      {{/is}}
+                      {{#is status 'completed'}}
+                        <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"></path><path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"></path></svg>
+                      {{/is}}
+                      {{#is status 'new'}}
+                        <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Zm0 2.445L6.615 5.5a.75.75 0 0 1-.564.41l-3.097.45 2.24 2.184a.75.75 0 0 1 .216.664l-.528 3.084 2.769-1.456a.75.75 0 0 1 .698 0l2.77 1.456-.53-3.084a.75.75 0 0 1 .216-.664l2.24-2.183-3.096-.45a.75.75 0 0 1-.564-.41L8 2.694Z"></path></svg>
+                      {{/is}}
+                    {{/is}}
+                  </span>
+                  <span>{{title}}</span>
+                </a>
+                {{#if pinned}}
+                  <span class="status-label status-label-pinned">{{t 'pinned'}}</span>
+                {{/if}}
+                {{#if featured}}
+                  <span class="status-label status-label-featured">{{t 'featured'}}</span>
+                {{/if}}
 
                 <div class="meta-group">
-                  <span class="meta-data">{{author.name}}</span>
-                  {{#if editor}}
-                    <span class="meta-data">{{date edited_at timeago=true}}</span>
-                    <span class="meta-data">{{t 'edited'}}</span>
-                  {{else}}
-                    <span class="meta-data">{{date created_at timeago=true}}</span>
-                  {{/if}}
-                </div>
-
-                {{#if content_tags}}
-                  <div class="content-tags" style="margin-top: 10px;">
-                    <ul class="tags-list" style="list-style: none; padding: 0; margin: 0; display: flex; gap: 8px; flex-wrap: wrap;">
+                  {{#if content_tags}}
+                    <ul class="tags-list">
                       {{#each content_tags}}
-                        <li class="content-tag" data-tag="{{name}}" style="background-color: #eee; border-radius: 4px; padding: 2px 8px; font-size: 12px;">
-                          <span class="tags-list-item" style="color: #333; text-decoration: none;">{{name}}</span>
+                        <li class="content-tag" data-tag="{{name}}">
+                          <span class="tags-list-item">{{name}}</span>
                         </li>
                       {{/each}}
                     </ul>
-                  </div>
-                {{/if}}
+                  {{/if}}
+
+                  <span class="meta-data">{{author.name}}</span>
+                  <span class="meta-data">opened this {{date created_at timeago=true}}</span>
+                </div>
               </span>
 
               <div class="post-overview-count striped-list-count">
-                <span class="striped-list-count-item">
-                  <span class="striped-list-number">{{vote_sum}}</span>
-                  {{t 'vote' count=vote_sum}}
-                </span>
-                <span class="striped-list-count-item">
-                  <span class="striped-list-number">{{comment_count}}</span>
-                  {{t 'comment' count=comment_count}}
-                </span>
+                {{#if vote_sum}}
+                  <span class="striped-list-count-item" title="{{vote_sum}} {{t 'vote' count=vote_sum}}">
+                    <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" style="margin-right: 4px;"><path d="M7 3.25A1.25 1.25 0 0 1 8.217 2.066l1.383-.881a1.25 1.25 0 0 1 1.622.882l.76 3.013h.768a1.25 1.25 0 0 1 1.25 1.25v1.25a1.25 1.25 0 0 1-.167.632l-2.36 4.489a1.25 1.25 0 0 1-1.067.632H5.35c-.69 0-1.25-.56-1.25-1.25v-5.474a1.25 1.25 0 0 1 .553-1.036L7 3.25ZM5.6 7.625v4.225a.25.25 0 0 0 .25.25h4.557a.25.25 0 0 0 .213-.126l2.36-4.49A.25.25 0 0 0 13 7.5V6.25a.25.25 0 0 0-.25-.25h-1.921l-.707-2.8a.25.25 0 0 0-.324-.176l-1.383.88a.25.25 0 0 0-.116.162L7.351 6.544a.25.25 0 0 1-.129.133l-1.622.948ZM1.5 6.5A1.5 1.5 0 0 0 0 8v5A1.5 1.5 0 0 0 1.5 14h2a1.5 1.5 0 0 0 1.5-1.5V8A1.5 1.5 0 0 0 3.5 6.5h-2Zm0 1.5h2a.25.25 0 0 1 .25.25v5a.25.25 0 0 1-.25.25h-2a.25.25 0 0 1-.25-.25V8A.25.25 0 0 1 1.5 8Z"/></svg>
+                    <span class="striped-list-number">{{vote_sum}}</span>
+                  </span>
+                {{/if}}
+                {{#if comment_count}}
+                  <span class="striped-list-count-item" title="{{comment_count}} {{t 'comment' count=comment_count}}">
+                    <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" style="margin-right: 4px;"><path d="M1.75 1h12.5c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0 1 14.25 13H8.061l-2.574 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25v-8.5C0 1.784.784 1 1.75 1ZM1.5 2.75v8.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-8.5a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25Z"></path></svg>
+                    <span class="striped-list-number">{{comment_count}}</span>
+                  </span>
+                {{/if}}
               </div>
             </section>
           </li>

--- a/templates/community_topic_page.hbs
+++ b/templates/community_topic_page.hbs
@@ -18,27 +18,29 @@
   {{breadcrumbs}}
   
   <header class="page-header">
-    <h1>
-      {{topic.name}}
-      {{#if topic.internal}}
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-lock" title="{{t 'internal'}}">
-          <rect width="12" height="9" x="2" y="7" fill="currentColor" rx="1" ry="1"/>
-          <path fill="none" stroke="currentColor" d="M4.5 7.5V4a3.5 3.5 0 017 0v3.5"/>
-        </svg>
+    <div class="page-header-title-container">
+      <h1>
+        {{topic.name}}
+        {{#if topic.internal}}
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-lock" title="{{t 'internal'}}">
+            <rect width="12" height="9" x="2" y="7" fill="currentColor" rx="1" ry="1"/>
+            <path fill="none" stroke="currentColor" d="M4.5 7.5V4a3.5 3.5 0 017 0v3.5"/>
+          </svg>
+        {{/if}}
+      </h1>
+      <p class="page-header-description">{{topic.description}}</p>
+    </div>
+    <div class="header-actions">
+      {{#if settings.show_follow_topic}}
+        <div class="community-follow">
+          {{subscribe}}
+        </div>
       {{/if}}
-    </h1>
-    <span class="post-to-community">
-      {{link 'new_post' topic_id=topic.id class='button button-large'}}
-    </span>
+      <span class="post-to-community">
+        {{link 'new_post' topic_id=topic.id class='button button-large'}}
+      </span>
+    </div>
   </header>
-  <div class="community-header">
-    <p class="page-header-description">{{topic.description}}</p>
-    {{#if settings.show_follow_topic}}
-      <div class="community-follow">
-        {{subscribe}}
-      </div>
-    {{/if}}
-  </div>
 
   <div class="topic-header">
     <span class="topic-filters">

--- a/templates/community_topic_page.hbs
+++ b/templates/community_topic_page.hbs
@@ -132,18 +132,21 @@
               </span>
 
               <div class="post-overview-count striped-list-count">
-                {{#if vote_sum}}
-                  <span class="striped-list-count-item" title="{{vote_sum}} {{t 'vote' count=vote_sum}}">
-                    <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" style="margin-right: 4px;"><path d="M7 3.25A1.25 1.25 0 0 1 8.217 2.066l1.383-.881a1.25 1.25 0 0 1 1.622.882l.76 3.013h.768a1.25 1.25 0 0 1 1.25 1.25v1.25a1.25 1.25 0 0 1-.167.632l-2.36 4.489a1.25 1.25 0 0 1-1.067.632H5.35c-.69 0-1.25-.56-1.25-1.25v-5.474a1.25 1.25 0 0 1 .553-1.036L7 3.25ZM5.6 7.625v4.225a.25.25 0 0 0 .25.25h4.557a.25.25 0 0 0 .213-.126l2.36-4.49A.25.25 0 0 0 13 7.5V6.25a.25.25 0 0 0-.25-.25h-1.921l-.707-2.8a.25.25 0 0 0-.324-.176l-1.383.88a.25.25 0 0 0-.116.162L7.351 6.544a.25.25 0 0 1-.129.133l-1.622.948ZM1.5 6.5A1.5 1.5 0 0 0 0 8v5A1.5 1.5 0 0 0 1.5 14h2a1.5 1.5 0 0 0 1.5-1.5V8A1.5 1.5 0 0 0 3.5 6.5h-2Zm0 1.5h2a.25.25 0 0 1 .25.25v5a.25.25 0 0 1-.25.25h-2a.25.25 0 0 1-.25-.25V8A.25.25 0 0 1 1.5 8Z"/></svg>
-                    <span class="striped-list-number">{{vote_sum}}</span>
-                  </span>
-                {{/if}}
-                {{#if comment_count}}
-                  <span class="striped-list-count-item" title="{{comment_count}} {{t 'comment' count=comment_count}}">
-                    <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" style="margin-right: 4px;"><path d="M1.75 1h12.5c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0 1 14.25 13H8.061l-2.574 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25v-8.5C0 1.784.784 1 1.75 1ZM1.5 2.75v8.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-8.5a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25Z"></path></svg>
-                    <span class="striped-list-number">{{comment_count}}</span>
-                  </span>
-                {{/if}}
+                <span class="striped-list-count-item {{#unless vote_sum}}is-empty{{/unless}}" title="{{vote_sum}} {{t 'vote' count=vote_sum}}">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="14" height="14" focusable="false" style="margin-right: 4px; flex-shrink: 0;">
+                    <g fill="none" stroke="currentColor">
+                      <path stroke-linejoin="round" d="M14.5 6.5a1 1 0 011 1c-.1 2.4-.4 8-2 8H5a.47.47 0 01-.5-.5V6.9a.55.55 0 01.3-.5c.6-.2 1.7-1 1.7-4.4a1.5 1.5 0 013 0v4.5z"/>
+                      <rect width="2" height="9" x=".5" y="6.5" rx=".5" ry=".5"/>
+                    </g>
+                  </svg>
+                  <span class="striped-list-number">{{vote_sum}}</span>
+                </span>
+                <span class="striped-list-count-item {{#unless comment_count}}is-empty{{/unless}}" title="{{comment_count}} {{t 'comment' count=comment_count}}">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="14" height="14" focusable="false" style="margin-right: 4px; flex-shrink: 0;">
+                    <path fill="none" stroke="currentColor" d="M1 .5h14c.3 0 .5.2.5.5v10c0 .3-.2.5-.5.5H8l-3.6 3.6c-.3.3-.9.1-.9-.4v-3.3H1c-.3 0-.5-.2-.5-.5V1C.5.7.7.5 1 .5z"/>
+                  </svg>
+                  <span class="striped-list-number">{{comment_count}}</span>
+                </span>
               </div>
             </section>
           </li>

--- a/templates/community_topic_page.hbs
+++ b/templates/community_topic_page.hbs
@@ -107,6 +107,18 @@
                     <span class="meta-data">{{date created_at timeago=true}}</span>
                   {{/if}}
                 </div>
+
+                {{#if content_tags}}
+                  <div class="content-tags" style="margin-top: 10px;">
+                    <ul class="tags-list" style="list-style: none; padding: 0; margin: 0; display: flex; gap: 8px; flex-wrap: wrap;">
+                      {{#each content_tags}}
+                        <li class="content-tag" data-tag="{{name}}" style="background-color: #eee; border-radius: 4px; padding: 2px 8px; font-size: 12px;">
+                          <a href="{{url}}" class="tags-list-item" style="color: #333; text-decoration: none;">{{name}}</a>
+                        </li>
+                      {{/each}}
+                    </ul>
+                  </div>
+                {{/if}}
               </span>
 
               <div class="post-overview-count striped-list-count">

--- a/tests/language-selector.spec.ts
+++ b/tests/language-selector.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Language Selector Navigation', () => {
+  test('should allow users to select languages regardless of device size', async ({ page }) => {
+    // Navigate to the Help Center homepage
+    await page.goto('/en-us');
+
+    // Make sure the page has fully loaded
+    await expect(page.locator('body')).toBeVisible();
+
+    const viewportSize = page.viewportSize();
+    // In our Banbury responsive logic, >= 1024 is desktop, < 1024 is tablet/mobile
+    const isMobileOrTablet = viewportSize && viewportSize.width < 1024;
+
+    if (isMobileOrTablet) {
+      // Test the Hamburger Menu language selector
+      const mobileMenuButton = page.locator('.menu-button-mobile');
+      await expect(mobileMenuButton).toBeVisible();
+      
+      // Open the hamburger menu
+      await mobileMenuButton.click();
+      
+      const mobileNav = page.locator('#user-nav-mobile');
+      await expect(mobileNav).toHaveAttribute('aria-expanded', 'true');
+
+      // Locate the language selector inside the mobile menu
+      const languageDropdownToggle = mobileNav.locator('.language-selector .dropdown-toggle');
+      await expect(languageDropdownToggle).toBeVisible();
+      
+      // Click to open the language dropdown
+      await languageDropdownToggle.click();
+      
+      const dropdownMenu = mobileNav.locator('.language-selector .dropdown-menu');
+      await expect(dropdownMenu).toBeVisible();
+
+      // Find Español and select it
+      const espanolLink = dropdownMenu.locator('a[role="menuitem"]:has-text("Español")');
+      await expect(espanolLink).toBeVisible();
+      
+      // Click and ensure navigation resolves successfully
+      await Promise.all([
+        page.waitForLoadState('domcontentloaded'),
+        espanolLink.click()
+      ]);
+
+      // Assert the URL natively redirected to the Spanish environment
+      expect(page.url()).toContain('/hc/es');
+
+    } else {
+      // Test the Desktop Footer language selector
+      const footerSelector = page.locator('.footer-language-selector');
+      await expect(footerSelector).toBeVisible();
+      
+      // Ensure it is scrolled into view (if at bottom of viewport)
+      await footerSelector.scrollIntoViewIfNeeded();
+
+      const languageDropdownToggle = footerSelector.locator('.dropdown-toggle');
+      await expect(languageDropdownToggle).toBeVisible();
+
+      // Click to open the dropdown
+      await languageDropdownToggle.click();
+
+      const dropdownMenu = footerSelector.locator('.dropdown-menu');
+      await expect(dropdownMenu).toBeVisible();
+
+      // Find Español and select it
+      const espanolLink = dropdownMenu.locator('a[role="menuitem"]:has-text("Español")');
+      await expect(espanolLink).toBeVisible();
+
+      // Click and ensure navigation resolves successfully
+      await Promise.all([
+        page.waitForLoadState('domcontentloaded'),
+        espanolLink.click()
+      ]);
+
+      // Assert the URL natively redirected to the Spanish environment
+      expect(page.url()).toContain('/hc/es');
+    }
+  });
+});

--- a/tests/manual_community_filters.md
+++ b/tests/manual_community_filters.md
@@ -1,0 +1,24 @@
+# Manual Testing Plan: Community Filters
+
+This document outlines the manual testing steps to validate the dropdown filter functionality on the community topic page.
+
+## Test 1: Title Toggle
+Validate that clicking the filter title toggles the dropdown visibility.
+1. Click the **"Filter by tag"** title.
+   * **Verify:** The dropdown menu opens.
+2. Click the **"Filter by tag"** title again.
+   * **Verify:** The dropdown menu closes.
+3. Repeat steps 1 & 2 for all other filters on the page (e.g., "Sort by", "Status").
+
+## Test 2: Outside Click
+Validate that the dropdown can be dismissed by clicking elsewhere on the page.
+1. Click any filter title to open its dropdown menu.
+2. Click anywhere else on the page outside of the dropdown menu.
+   * **Verify:** The dropdown menu closes immediately.
+
+## Test 3: Selection Rendering
+Validate that making a selection closes the dropdown and re-renders the page with the appropriate filters applied.
+1. Click the **"Filter by tag"** title to open the dropdown menu.
+2. Click on any specific tag selection within the menu.
+   * **Verify:** The dropdown menu closes automatically.
+   * **Verify:** The page reloads or renders to show only the posts matching the selected tag.

--- a/tests/manual_community_filters.md
+++ b/tests/manual_community_filters.md
@@ -22,3 +22,94 @@ Validate that making a selection closes the dropdown and re-renders the page wit
 2. Click on any specific tag selection within the menu.
    * **Verify:** The dropdown menu closes automatically.
    * **Verify:** The page reloads or renders to show only the posts matching the selected tag.
+
+---
+
+## Responsive Design Tests
+
+> Test at three viewport widths:
+> - **Mobile** — < 768px (e.g., iPhone SE: 375px)
+> - **Tablet** — 768px–1023px (e.g., iPad: 768px)
+> - **Desktop** — ≥ 1024px
+
+---
+
+## Test 4: Header Actions Layout (Mobile)
+Validate that the Follow and New Post buttons stack vertically on mobile.
+1. Set viewport to **375px** wide.
+2. Navigate to any community topic page.
+   * **Verify:** The **Follow** button and **New Post** button are stacked vertically, each taking full width.
+   * **Verify:** There is no horizontal overflow or clipping of buttons.
+
+## Test 5: Header Actions Layout (Tablet & Desktop)
+Validate that the Follow and New Post buttons align horizontally on wider screens.
+1. Set viewport to **768px** or wider.
+2. Navigate to any community topic page.
+   * **Verify:** The **Follow** button and **New Post** button appear side-by-side on the same row.
+   * **Verify:** Neither button is stretched wider than its content.
+
+## Test 6: Follow Button — Follower Count Visibility
+Validate that the follower count is hidden on mobile and visible on tablet+.
+1. Set viewport to **375px** wide.
+   * **Verify:** The follower count (the number shown after the divider inside the Follow button) is **not visible**.
+2. Set viewport to **768px** or wider.
+   * **Verify:** The follower count **is visible** alongside the button label.
+
+## Test 7: Post Count Icon Alignment
+Validate that the vote and comment count columns align consistently across all posts, regardless of whether counts are present.
+1. Navigate to a community topic page with a mix of posts — some with votes and comments, some with neither.
+2. At **all three viewport sizes**:
+   * **Verify:** The thumbs-up icon column is in the **same horizontal position** on every post row.
+   * **Verify:** The comment icon column is in the **same horizontal position** on every post row.
+   * **Verify:** Posts without a vote or comment count show **no icon** in that slot (not a zero or a dimmed icon).
+
+## Test 8: Post Count Icon Styling
+Validate that both count icons use the Zendesk Garden outline/stroke style.
+1. At any viewport size, inspect the post list.
+   * **Verify:** The thumbs-up icon is **outline/stroke** style (not filled).
+   * **Verify:** The comment/speech-bubble icon is **outline/stroke** style (not filled).
+   * **Verify:** Both icons use the same visual weight and are visually consistent.
+
+## Test 9: Topic Filter Dropdown Layout (Mobile)
+Validate that the filter dropdowns are accessible and usable on small screens.
+1. Set viewport to **375px** wide.
+2. Navigate to a community topic page.
+   * **Verify:** The filter dropdowns (Sort, Filter) each appear as a **full-width block** with a visible border separating them.
+   * **Verify:** Tapping a filter opens its dropdown.
+   * **Verify:** The dropdown menu does not overflow the screen horizontally.
+
+## Test 10: Topic Filter Dropdown Layout (Tablet & Desktop)
+Validate that filters display inline on wider screens.
+1. Set viewport to **768px** or wider.
+2. Navigate to a community topic page.
+   * **Verify:** The filter dropdowns appear **inline** (side by side), not stacked.
+   * **Verify:** There are no top borders on the individual filter items at tablet/desktop width.
+
+## Test 11: Breadcrumb Color
+Validate that breadcrumb text and links render in the correct muted grey.
+1. At any viewport size, inspect the breadcrumbs near the top of the community topic page.
+   * **Verify:** Breadcrumb text is a **muted grey** (matching the filter dropdown label color).
+   * **Verify:** Breadcrumb **links** (anchor tags) are the same grey — not the teal/brand link color.
+   * **Verify:** The separator `>` between crumbs is also grey.
+
+## Test 12: Post Status Icon Colors
+Validate that each post status icon uses the correct brand palette color.
+1. Navigate to a topic page that contains posts in multiple statuses.
+   * **Verify:** **Open** posts show a **green** (`#71AA32`) status icon.
+   * **Verify:** **New** posts show a **gold/yellow** (`#E1BC21`) status icon.
+   * **Verify:** **Planned** posts show a **teal** (`#009EB9`) status icon.
+   * **Verify:** **Not planned** posts show a **mid-grey** (`#989B9F`) status icon.
+   * **Verify:** **Answered** and **Completed** posts show a **green** (`#71AA32`) status icon.
+
+## Test 13: Touch Interaction (Mobile)
+Validate that dropdowns and buttons respond correctly to touch on mobile devices.
+1. Using a real device or browser touch emulation at **375px**:
+2. Tap a filter dropdown toggle.
+   * **Verify:** The dropdown opens on tap (not requiring hover).
+3. Tap a menu item inside the dropdown.
+   * **Verify:** The selection is applied and the dropdown closes.
+4. Tap the **New Post** button.
+   * **Verify:** The button responds to tap and navigates to the new post form.
+5. Tap the **Follow** button.
+   * **Verify:** The follow state toggles correctly.
+


### PR DESCRIPTION
## Description
This PR aims to make the community post page easier to consume and navigate for end users. 

- Add a filter for content tags
- calm down the UI to focus on post titles
- move the following button to be on the side of the title
- add content tag badges so users can scan posts easier
- set breadcrumbs, filters and post meta info to a muted gray color
- set the status of the posts as an icon with hover text

fixes #20 and fixes #21 

## Screenshots
#### Pre Changes
<img width="1604" height="785" alt="image" src="https://github.com/user-attachments/assets/4c44ef27-b015-48dc-95a6-9c6070fa7d2e" />

#### Post Changes

1: muted colors |  2: Content Tags |   3: Status Icons
<img width="802" height="626" alt="image" src="https://github.com/user-attachments/assets/bcb089d6-0cf5-480b-829c-e8dd4d1816cc" />

Status Icons Hover Text: 
<img width="1502" height="483" alt="firefox_PVKF7kFTR3" src="https://github.com/user-attachments/assets/8498d041-d144-42a2-8ad7-7396387f27a1" />

##### All Changes
<img width="1571" height="2366" alt="image" src="https://github.com/user-attachments/assets/bb72212c-9941-4e79-8955-76580ef199e3" />


## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile